### PR TITLE
fix uninstallable ant; switch precedence of outputs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,11 +11,11 @@ jobs:
       linux_64_openjdk11:
         CONFIG: linux_64_openjdk11
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_openjdk8:
         CONFIG: linux_64_openjdk8
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-2019
   strategy:
     matrix:
       win_64_openjdk11:

--- a/.ci_support/linux_64_openjdk11.yaml
+++ b/.ci_support/linux_64_openjdk11.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 openjdk:
 - '11'
 pin_run_as_build:
@@ -13,6 +13,3 @@ pin_run_as_build:
     max_pin: x.x
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.ci_support/linux_64_openjdk8.yaml
+++ b/.ci_support/linux_64_openjdk8.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 openjdk:
 - '8'
 pin_run_as_build:
@@ -13,6 +13,3 @@ pin_run_as_build:
     max_pin: x.x
 target_platform:
 - linux-64
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -5,6 +5,8 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+# -*- mode: jinja-shell -*-
+
 set -xeuo pipefail
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
 source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
@@ -25,10 +27,10 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
-GET_BOA=boa
-BUILD_CMD=mambabuild
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
+
+mamba install --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
+mamba update --update-specs --yes --quiet "conda-forge-ci-setup=3" conda-build pip boa -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -53,7 +55,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
     ( startgroup "Validating outputs" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# -*- mode: jinja-shell -*-
+
 source .scripts/logging_utils.sh
 
 set -xe
@@ -9,7 +11,7 @@ MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
 ( startgroup "Installing a fresh version of Miniforge" ) 2> /dev/null
 
 MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
-MINIFORGE_FILE="Miniforge3-MacOSX-$(uname -m).sh"
+MINIFORGE_FILE="Mambaforge-MacOSX-$(uname -m).sh"
 curl -L -O "${MINIFORGE_URL}/${MINIFORGE_FILE}"
 rm -rf ${MINIFORGE_HOME}
 bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
@@ -18,14 +20,12 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 ( startgroup "Configuring conda" ) 2> /dev/null
 
-GET_BOA=boa
-BUILD_CMD=mambabuild
-
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-}
+mamba install -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
+mamba update -n base --update-specs --quiet --yes "conda-forge-ci-setup=3" conda-build pip boa
 
 
 
@@ -55,7 +55,7 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-conda $BUILD_CMD ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
+conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml ${EXTRA_CB_OPTIONS:-}
 ( startgroup "Validating outputs" ) 2> /dev/null
 
 validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 0d10dc97031882ccdcadf47163a5ee9bc4f0104a694a1399c2eda1b93f9a739b
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -18,7 +18,7 @@ requirements:
     - openjdk
 
 outputs:
-  - name: apache-ant
+  - name: ant
     script: build-pkg.sh   # [not win]
     script: build-pkg.bat  # [win]
     requirements:
@@ -31,13 +31,13 @@ outputs:
         - ant -help
         - ant -version
 
-  # compatibility output for naming of package in defaults channel
-  - name: ant
+  # compatibility output for previous name of package in conda-forge
+  - name: apache-ant
+    build:
+      noarch: generic
     requirements:
-      host:
-        - {{ pin_subpackage('apache-ant', exact=True) }}
       run:
-        - {{ pin_subpackage('apache-ant', exact=True) }}
+        - {{ pin_subpackage('ant', exact=True) }}
     test:
       commands:
         - ant -help


### PR DESCRIPTION
Trying to install `ant` actually fails. Taking some [inspiration](https://github.com/conda-forge/importlib_metadata-feedstock/blob/master/recipe/meta.yaml#L37-L42) from importlib_metadata feedstock.